### PR TITLE
feat: add standalone Expo mobile app with auth, CRUD, scanner, and offline cache

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,18 @@
+# dependencies
+/node_modules
+
+# expo
+.expo
+.expo-shared
+web-build
+
+# macOS
+.DS_Store
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# transient
+*.tmp

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,23 +1,59 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { DarkTheme, DefaultTheme, NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useColorScheme } from 'react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister';
+import { persistQueryClient } from '@tanstack/react-query-persist-client';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import NetInfo from '@react-native-community/netinfo';
 import HomeScreen from './src/screens/HomeScreen';
+import LoginScreen from './src/screens/LoginScreen';
+import AssetDetailsScreen from './src/screens/AssetDetailsScreen';
+import EditAssetScreen from './src/screens/EditAssetScreen';
+import CreateAssetScreen from './src/screens/CreateAssetScreen';
+import BarcodeScannerScreen from './src/screens/BarcodeScannerScreen';
+import { AuthProvider } from './src/auth/AuthContext';
 
 const Stack = createNativeStackNavigator();
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000,
+      gcTime: 5 * 60_000,
+      retry: 1
+    }
+  }
+});
 
 export default function App() {
   const scheme = useColorScheme();
+  useEffect(() => {
+    const persister = createAsyncStoragePersister({ storage: AsyncStorage });
+    persistQueryClient({ queryClient, persister, maxAge: 24 * 60 * 60 * 1000 });
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      if (state.isConnected) {
+        queryClient.resumePausedMutations();
+        queryClient.invalidateQueries();
+      }
+    });
+    return () => unsubscribe();
+  }, []);
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack.Navigator>
-          <Stack.Screen name="Home" component={HomeScreen} options={{ title: 'LP Management' }} />
-        </Stack.Navigator>
-      </NavigationContainer>
-    </QueryClientProvider>
+    <AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <Stack.Navigator>
+            <Stack.Screen name="Login" component={LoginScreen} options={{ headerShown: false }} />
+            <Stack.Screen name="Home" component={HomeScreen} options={{ title: 'LP Management' }} />
+            <Stack.Screen name="AssetDetails" component={AssetDetailsScreen} options={{ title: 'Asset details' }} />
+            <Stack.Screen name="EditAsset" component={EditAssetScreen} options={{ title: 'Edit asset' }} />
+            <Stack.Screen name="CreateAsset" component={CreateAssetScreen} options={{ title: 'Create asset' }} />
+            <Stack.Screen name="BarcodeScanner" component={BarcodeScannerScreen} options={{ title: 'Scan barcode' }} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </QueryClientProvider>
+    </AuthProvider>
   );
 }

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { DarkTheme, DefaultTheme, NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { useColorScheme } from 'react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import HomeScreen from './src/screens/HomeScreen';
+
+const Stack = createNativeStackNavigator();
+const queryClient = new QueryClient();
+
+export default function App() {
+  const scheme = useColorScheme();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack.Navigator>
+          <Stack.Screen name="Home" component={HomeScreen} options={{ title: 'LP Management' }} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </QueryClientProvider>
+  );
+}

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,31 @@
+# LP Management Mobile
+
+A separate Expo React Native app for LP Management, kept isolated from the Next.js web app.
+
+## Prerequisites
+- Node.js 18+
+- npm or yarn
+- Expo CLI (`npm i -g expo` optional)
+
+## Setup
+```bash
+cd mobile
+npm install
+```
+
+Create `.env` or use Expo env:
+```
+EXPO_PUBLIC_API_BASE_URL=https://r1iqp059n5.execute-api.eu-west-2.amazonaws.com/dev
+```
+
+## Run
+```bash
+npm start        # launch Expo dev tools
+npm run android  # run on Android Emulator / device
+npm run ios      # run on iOS Simulator / device
+npm run web      # optional web preview
+```
+
+## Notes
+- No changes are made to the existing web application.
+- Nothing will be pushed without your explicit confirmation.

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,14 @@
+{
+  "expo": {
+    "name": "LP Management Mobile",
+    "slug": "lp-management-mobile",
+    "scheme": "lpmanagement",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "updates": { "fallbackToCacheTimeout": 0 },
+    "assetBundlePatterns": ["**/*"],
+    "ios": { "supportsTablet": true },
+    "android": {},
+    "web": { "bundler": "metro", "output": "static" }
+  }
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,9 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      'react-native-reanimated/plugin'
+    ]
+  };
+};

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,5 @@
+import 'react-native-gesture-handler';
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "^18.3.12",
-    "@types/react-native": "^0.76.0",
     "typescript": "^5.5.4",
     "eslint": "^9.12.0",
     "eslint-config-universe": "^12.1.0"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "lp-management-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "expo": "~52.0.19",
+    "expo-status-bar": "~2.0.0",
+    "react": "18.3.1",
+    "react-native": "0.76.3",
+    "react-native-safe-area-context": "^4.10.5",
+    "react-native-screens": "^4.3.0",
+    "@react-navigation/native": "^6.1.18",
+    "@react-navigation/native-stack": "^6.9.26",
+    "react-native-gesture-handler": "^2.16.2",
+    "react-native-reanimated": "^3.15.5",
+    "@tanstack/react-query": "^5.52.1",
+    "axios": "^1.7.7"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.2",
+    "@types/react": "^18.3.12",
+    "@types/react-native": "^0.76.0",
+    "typescript": "^5.5.4",
+    "eslint": "^9.12.0",
+    "eslint-config-universe": "^12.1.0"
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -22,7 +22,17 @@
     "react-native-gesture-handler": "^2.16.2",
     "react-native-reanimated": "^3.15.5",
     "@tanstack/react-query": "^5.52.1",
-    "axios": "^1.7.7"
+    "axios": "^1.7.7",
+    "aws-amplify": "^6.15.3",
+    "@react-native-async-storage/async-storage": "^1.23.1",
+    "@tanstack/react-query-persist-client": "^5.52.1",
+    "@tanstack/query-async-storage-persister": "^5.52.1",
+    "@react-native-community/netinfo": "^11.3.3",
+    "react-hook-form": "^7.53.1",
+    "zod": "^3.23.8",
+    "@hookform/resolvers": "^3.9.0",
+    "expo-barcode-scanner": "~13.0.2",
+    "expo-secure-store": "~14.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -31,7 +31,7 @@
     "react-hook-form": "^7.53.1",
     "zod": "^3.23.8",
     "@hookform/resolvers": "^3.9.0",
-    "expo-barcode-scanner": "~13.0.2",
+    "expo-barcode-scanner": "~14.0.0",
     "expo-secure-store": "~14.0.0"
   },
   "devDependencies": {

--- a/mobile/src/api/assets.ts
+++ b/mobile/src/api/assets.ts
@@ -1,0 +1,69 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useApiClient } from './client';
+import { Asset } from '../types/asset';
+
+export function useAssetsQuery() {
+  const api = useApiClient();
+  return useQuery<Asset[]>({
+    queryKey: ['assets'],
+    queryFn: async () => {
+      const res = await api.get('/assets');
+      return res.data as Asset[];
+    }
+  });
+}
+
+export function useAssetQuery(assetId: string) {
+  const api = useApiClient();
+  return useQuery<Asset>({
+    queryKey: ['asset', assetId],
+    queryFn: async () => {
+      const res = await api.get(`/assets/${assetId}`);
+      return res.data as Asset;
+    },
+    enabled: !!assetId
+  });
+}
+
+export function useCreateAsset() {
+  const api = useApiClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: Partial<Asset>) => {
+      const res = await api.post('/assets', payload);
+      return res.data as Asset;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['assets'] });
+    }
+  });
+}
+
+export function useUpdateAsset(assetId: string) {
+  const api = useApiClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: Partial<Asset>) => {
+      const res = await api.put(`/assets/${assetId}`, payload);
+      return res.data as Asset;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['assets'] });
+      qc.invalidateQueries({ queryKey: ['asset', assetId] });
+    }
+  });
+}
+
+export function useDeleteAsset(assetId: string) {
+  const api = useApiClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const res = await api.delete(`/assets/${assetId}`);
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['assets'] });
+    }
+  });
+}

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import { useAuth } from '../auth/AuthContext';
+
+export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL || 'https://r1iqp059n5.execute-api.eu-west-2.amazonaws.com/dev';
+
+// Creates an axios instance that attaches Cognito ID token if available
+export function useApiClient() {
+  const { getIdToken } = useAuth();
+
+  const instance = axios.create({ baseURL: API_BASE_URL });
+
+  instance.interceptors.request.use(async (config) => {
+    const token = await getIdToken();
+    if (token) {
+      config.headers = {
+        ...(config.headers || {}),
+        Authorization: `Bearer ${token}`
+      } as any;
+    }
+    return config;
+  });
+
+  return instance;
+}

--- a/mobile/src/auth/AuthContext.tsx
+++ b/mobile/src/auth/AuthContext.tsx
@@ -1,0 +1,81 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { getCurrentUser, signIn, signOut, fetchAuthSession } from 'aws-amplify/auth';
+import { configureAmplify } from '../lib/amplify';
+
+export interface MobileUser {
+  username: string;
+  email?: string;
+}
+
+interface AuthContextValue {
+  user: MobileUser | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  signIn: (email: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+  getIdToken: () => Promise<string | null>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<MobileUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    configureAmplify();
+    checkAuth();
+  }, []);
+
+  async function checkAuth() {
+    try {
+      const current = await getCurrentUser();
+      const session = await fetchAuthSession();
+      if (current && session.tokens) {
+        setUser({ username: current.username, email: current.signInDetails?.loginId });
+      } else {
+        setUser(null);
+      }
+    } catch {
+      setUser(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function handleSignIn(email: string, password: string) {
+    const { isSignedIn } = await signIn({ username: email, password });
+    if (isSignedIn) await checkAuth();
+  }
+
+  async function handleSignOut() {
+    await signOut();
+    setUser(null);
+  }
+
+  async function getIdToken() {
+    try {
+      const session = await fetchAuthSession();
+      return session.tokens?.idToken?.toString() ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  const value: AuthContextValue = {
+    user,
+    isLoading,
+    isAuthenticated: !!user,
+    signIn: handleSignIn,
+    signOut: handleSignOut,
+    getIdToken
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/mobile/src/components/Themed.tsx
+++ b/mobile/src/components/Themed.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Text as RNText, View as RNView, TextInput as RNTextInput, StyleSheet, Pressable } from 'react-native';
+import { colors } from '../theme/colors';
+
+export function View(props: React.ComponentProps<typeof RNView>) {
+  return <RNView {...props} />;
+}
+
+export function Text(props: React.ComponentProps<typeof RNText>) {
+  return <RNText style={[{ color: colors.text }, props.style]} {...props} />;
+}
+
+export function TextInput(props: React.ComponentProps<typeof RNTextInput>) {
+  return (
+    <RNTextInput
+      placeholderTextColor={colors.mutedText}
+      style={[styles.input, props.style]}
+      {...props}
+    />
+  );
+}
+
+export function Button({ title, onPress }: { title: string; onPress?: () => void }) {
+  return (
+    <Pressable onPress={onPress} style={styles.button}>
+      <RNText style={styles.buttonText}>{title}</RNText>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+    backgroundColor: '#fff'
+  },
+  button: {
+    backgroundColor: colors.primary,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    alignItems: 'center'
+  },
+  buttonText: {
+    color: colors.primaryText,
+    fontWeight: '600'
+  }
+});

--- a/mobile/src/lib/amplify.ts
+++ b/mobile/src/lib/amplify.ts
@@ -1,0 +1,19 @@
+import { Amplify } from 'aws-amplify';
+
+const userPoolId = process.env.EXPO_PUBLIC_COGNITO_USER_POOL_ID || 'eu-west-2_uZhfIxAA7';
+const userPoolClientId = process.env.EXPO_PUBLIC_COGNITO_USER_POOL_CLIENT_ID || '24a2n8fjsq4tvrtfdgtqkp71fl';
+
+const cognitoConfig = {
+  Auth: {
+    Cognito: {
+      userPoolId,
+      userPoolClientId,
+      signUpVerificationMethod: 'code' as const,
+      loginWith: { email: true, username: false }
+    }
+  }
+};
+
+export function configureAmplify() {
+  Amplify.configure(cognitoConfig);
+}

--- a/mobile/src/screens/AssetDetailsScreen.tsx
+++ b/mobile/src/screens/AssetDetailsScreen.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet, View, ScrollView } from 'react-native';
+import { Text } from '../components/Themed';
+import { useRoute, useNavigation } from '@react-navigation/native';
+import { useAssetQuery } from '../api/assets';
+import { Button } from '../components/Themed';
+
+export default function AssetDetailsScreen() {
+  const route = useRoute<any>();
+  const navigation = useNavigation<any>();
+  const { assetId } = route.params as { assetId: string };
+  const { data: asset, isLoading } = useAssetQuery(assetId);
+
+  if (isLoading || !asset) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <Text>Loading...</Text>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
+        <Text style={styles.title}>{asset.assetBarcode}</Text>
+        <Text>{asset.assetType} • {asset.status}</Text>
+        {asset.wing ? <Text>Wing: {asset.wing}</Text> : null}
+        {asset.roomName ? <Text>Room: {asset.roomName}</Text> : null}
+        {asset.notes ? <Text>Notes: {asset.notes}</Text> : null}
+
+        <View style={{ height: 12 }} />
+        <Button title="Edit" onPress={() => navigation.navigate('EditAsset', { assetId })} />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  title: { fontSize: 22, fontWeight: '700', marginBottom: 8 }
+});

--- a/mobile/src/screens/BarcodeScannerScreen.tsx
+++ b/mobile/src/screens/BarcodeScannerScreen.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { SafeAreaView, StyleSheet, View } from 'react-native';
+import { BarCodeScanner } from 'expo-barcode-scanner';
+import { Text, Button } from '../components/Themed';
+import { useNavigation, useRoute } from '@react-navigation/native';
+
+export default function BarcodeScannerScreen() {
+  const navigation = useNavigation<any>();
+  const route = useRoute<any>();
+  const onScanned = route.params?.onScanned as (code: string) => void;
+
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
+  const [scanned, setScanned] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await BarCodeScanner.requestPermissionsAsync();
+      setHasPermission(status === 'granted');
+    })();
+  }, []);
+
+  function handleBarCodeScanned({ data }: { data: string }) {
+    if (scanned) return;
+    setScanned(true);
+    if (onScanned) onScanned(data);
+    navigation.goBack();
+  }
+
+  if (hasPermission === null) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <Text>Requesting camera permission...</Text>
+      </SafeAreaView>
+    );
+  }
+
+  if (hasPermission === false) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <Text>No access to camera</Text>
+        <Button title="Go back" onPress={() => navigation.goBack()} />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <BarCodeScanner
+        onBarCodeScanned={handleBarCodeScanned}
+        style={StyleSheet.absoluteFillObject}
+      />
+      <View style={styles.overlay}>
+        <Text style={styles.prompt}>Align barcode within the frame</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  overlay: {
+    position: 'absolute',
+    bottom: 40,
+    left: 0,
+    right: 0,
+    alignItems: 'center'
+  },
+  prompt: {
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    color: '#fff',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8
+  }
+});

--- a/mobile/src/screens/CreateAssetScreen.tsx
+++ b/mobile/src/screens/CreateAssetScreen.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import { SafeAreaView, StyleSheet, View, Alert } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useForm, Controller } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Text, TextInput, Button } from '../components/Themed';
+import { useCreateAsset } from '../api/assets';
+
+const schema = z.object({
+  assetBarcode: z.string().min(1),
+  assetType: z.string().min(1),
+  status: z.enum(['ACTIVE', 'INACTIVE', 'MAINTENANCE', 'DECOMMISSIONED']).default('ACTIVE'),
+  wing: z.string().optional(),
+  roomName: z.string().optional(),
+  notes: z.string().optional()
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export default function CreateAssetScreen() {
+  const navigation = useNavigation<any>();
+  const createMutation = useCreateAsset();
+  const { control, handleSubmit, setValue } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { assetBarcode: '', assetType: '', status: 'ACTIVE', wing: '', roomName: '', notes: '' }
+  });
+
+  const [scanning, setScanning] = useState(false);
+
+  function startScan() {
+    navigation.navigate('BarcodeScanner', {
+      onScanned: (code: string) => {
+        setValue('assetBarcode', code);
+        setScanning(false);
+      }
+    });
+    setScanning(true);
+  }
+
+  async function onSubmit(values: FormValues) {
+    try {
+      await createMutation.mutateAsync({ ...values, filterNeeded: false, filtersOn: false, augmentedCare: false });
+      Alert.alert('Created', 'Asset created successfully');
+      navigation.reset({ index: 0, routes: [{ name: 'Home' }] });
+    } catch (e) {
+      Alert.alert('Error', 'Failed to create asset');
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={{ padding: 16, gap: 12 }}>
+        <Text>Asset Barcode</Text>
+        <Controller name="assetBarcode" control={control} render={({ field: { onChange, value } }) => (
+          <TextInput value={value} onChangeText={onChange} placeholder="Scan or enter barcode" />
+        )} />
+        <Button title={scanning ? 'Scanning...' : 'Scan Barcode'} onPress={startScan} />
+
+        <Text>Asset Type</Text>
+        <Controller name="assetType" control={control} render={({ field: { onChange, value } }) => (
+          <TextInput value={value} onChangeText={onChange} placeholder="Asset Type" />
+        )} />
+
+        <Text>Status</Text>
+        <Controller name="status" control={control} render={({ field: { onChange, value } }) => (
+          <TextInput value={value} onChangeText={onChange} placeholder="ACTIVE/INACTIVE/MAINTENANCE/DECOMMISSIONED" />
+        )} />
+
+        <Text>Wing</Text>
+        <Controller name="wing" control={control} render={({ field: { onChange, value } }) => (
+          <TextInput value={value} onChangeText={onChange} placeholder="Wing" />
+        )} />
+
+        <Text>Room Name</Text>
+        <Controller name="roomName" control={control} render={({ field: { onChange, value } }) => (
+          <TextInput value={value} onChangeText={onChange} placeholder="Room Name" />
+        )} />
+
+        <Text>Notes</Text>
+        <Controller name="notes" control={control} render={({ field: { onChange, value } }) => (
+          <TextInput value={value} onChangeText={onChange} placeholder="Notes" />
+        )} />
+
+        <Button title="Create" onPress={handleSubmit(onSubmit)} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({ container: { flex: 1 } });

--- a/mobile/src/screens/EditAssetScreen.tsx
+++ b/mobile/src/screens/EditAssetScreen.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet, View, Alert } from 'react-native';
+import { useRoute, useNavigation } from '@react-navigation/native';
+import { useForm, Controller } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Text, TextInput, Button } from '../components/Themed';
+import { useAssetQuery, useUpdateAsset } from '../api/assets';
+import { AssetStatus } from '../types/asset';
+
+const schema = z.object({
+  assetType: z.string().min(1),
+  status: z.custom<AssetStatus>(),
+  wing: z.string().min(1).optional(),
+  roomName: z.string().optional(),
+  notes: z.string().optional()
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export default function EditAssetScreen() {
+  const route = useRoute<any>();
+  const navigation = useNavigation<any>();
+  const { assetId } = route.params as { assetId: string };
+  const { data: asset } = useAssetQuery(assetId);
+  const updateMutation = useUpdateAsset(assetId);
+
+  const { control, handleSubmit } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    values: {
+      assetType: asset?.assetType || '',
+      status: (asset?.status as AssetStatus) || 'ACTIVE',
+      wing: asset?.wing || '',
+      roomName: asset?.roomName || '',
+      notes: asset?.notes || ''
+    }
+  });
+
+  async function onSubmit(values: FormValues) {
+    try {
+      await updateMutation.mutateAsync(values);
+      Alert.alert('Updated', 'Asset updated successfully');
+      navigation.goBack();
+    } catch (e) {
+      Alert.alert('Error', 'Failed to update asset');
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={{ padding: 16, gap: 12 }}>
+        <Text>Asset Type</Text>
+        <Controller name="assetType" control={control} render={({ field: { onChange, value } }) => (
+          <TextInput value={value} onChangeText={onChange} placeholder="Asset Type" />
+        )} />
+
+        <Text>Status</Text>
+        <Controller name="status" control={control} render={({ field: { onChange, value } }) => (
+          <TextInput value={value} onChangeText={onChange} placeholder="Status (ACTIVE/INACTIVE/MAINTENANCE/DECOMMISSIONED)" />
+        )} />
+
+        <Text>Wing</Text>
+        <Controller name="wing" control={control} render={({ field: { onChange, value } }) => (
+          <TextInput value={value} onChangeText={onChange} placeholder="Wing" />
+        )} />
+
+        <Text>Room Name</Text>
+        <Controller name="roomName" control={control} render={({ field: { onChange, value } }) => (
+          <TextInput value={value} onChangeText={onChange} placeholder="Room Name" />
+        )} />
+
+        <Text>Notes</Text>
+        <Controller name="notes" control={control} render={({ field: { onChange, value } }) => (
+          <TextInput value={value} onChangeText={onChange} placeholder="Notes" />
+        )} />
+
+        <Button title="Save" onPress={handleSubmit(onSubmit)} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({ container: { flex: 1 } });

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -1,0 +1,65 @@
+import React, { useCallback } from 'react';
+import { SafeAreaView, StyleSheet, View, FlatList, RefreshControl, ActivityIndicator, TouchableOpacity } from 'react-native';
+import { Text } from '../components/Themed';
+import { useAssetsQuery } from '../api/assets';
+import { useAuth } from '../auth/AuthContext';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+
+export default function HomeScreen() {
+  const { isAuthenticated } = useAuth();
+  const navigation = useNavigation<any>();
+  const { data, isLoading, isError, refetch, isRefetching } = useAssetsQuery();
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!isAuthenticated) {
+        navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
+      }
+    }, [isAuthenticated])
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Assets</Text>
+        <TouchableOpacity onPress={() => navigation.navigate('CreateAsset')}> 
+          <Text style={{ color: '#0ea5e9', fontWeight: '600' }}>+ Add</Text>
+        </TouchableOpacity>
+      </View>
+
+      {isLoading ? (
+        <View style={styles.center}><ActivityIndicator /><Text>Loading...</Text></View>
+      ) : isError ? (
+        <View style={styles.center}><Text>Failed to load assets.</Text></View>
+      ) : (
+        <FlatList
+          data={data || []}
+          keyExtractor={(item) => String(item.id)}
+          renderItem={({ item }) => (
+            <TouchableOpacity onPress={() => navigation.navigate('AssetDetails', { assetId: item.id })}>
+              <View style={styles.card}>
+                <Text style={styles.cardTitle}>{item.assetBarcode || 'Unknown'}</Text>
+                <Text style={styles.cardSubtitle}>{item.assetType} • {item.status}</Text>
+                {item.wing ? <Text style={styles.cardMeta}>Wing: {item.wing}</Text> : null}
+              </View>
+            </TouchableOpacity>
+          )}
+          ItemSeparatorComponent={() => <View style={{ height: 8 }} />}
+          contentContainerStyle={{ padding: 16 }}
+          refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  header: { paddingHorizontal: 16, paddingVertical: 12, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  title: { fontSize: 20, fontWeight: '600' },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 8 },
+  card: { padding: 12, borderRadius: 12, backgroundColor: '#f6f6f7' },
+  cardTitle: { fontSize: 16, fontWeight: '600' },
+  cardSubtitle: { marginTop: 2, color: '#4b5563' },
+  cardMeta: { marginTop: 4, color: '#6b7280' }
+});

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet, View } from 'react-native';
+import { useForm, Controller } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Text, TextInput, Button } from '../components/Themed';
+import { useAuth } from '../auth/AuthContext';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6)
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export default function LoginScreen() {
+  const { signIn } = useAuth();
+  const { control, handleSubmit, formState: { isSubmitting, errors } } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: '', password: '' }
+  });
+
+  async function onSubmit(values: FormValues) {
+    await signIn(values.email, values.password);
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={{ gap: 12 }}>
+        <Text style={styles.title}>Sign in</Text>
+        <Controller
+          control={control}
+          name="email"
+          render={({ field: { onChange, onBlur, value } }) => (
+            <TextInput
+              placeholder="Email"
+              autoCapitalize="none"
+              keyboardType="email-address"
+              onBlur={onBlur}
+              onChangeText={onChange}
+              value={value}
+            />
+          )}
+        />
+        {errors.email && <Text style={styles.error}>Enter a valid email</Text>}
+
+        <Controller
+          control={control}
+          name="password"
+          render={({ field: { onChange, onBlur, value } }) => (
+            <TextInput
+              placeholder="Password"
+              secureTextEntry
+              onBlur={onBlur}
+              onChangeText={onChange}
+              value={value}
+            />
+          )}
+        />
+        {errors.password && <Text style={styles.error}>Password must be at least 6 characters</Text>}
+
+        <Button title={isSubmitting ? 'Signing in...' : 'Sign in'} onPress={handleSubmit(onSubmit)} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16, justifyContent: 'center' },
+  title: { fontSize: 24, fontWeight: '700', marginBottom: 8 },
+  error: { color: '#ef4444' }
+});

--- a/mobile/src/theme/colors.ts
+++ b/mobile/src/theme/colors.ts
@@ -1,0 +1,12 @@
+export const colors = {
+  background: '#ffffff',
+  surface: '#f6f6f7',
+  text: '#111827',
+  mutedText: '#4b5563',
+  primary: '#0ea5e9',
+  primaryText: '#ffffff',
+  border: '#e5e7eb',
+  success: '#10b981',
+  warning: '#f59e0b',
+  danger: '#ef4444'
+};

--- a/mobile/src/types/asset.ts
+++ b/mobile/src/types/asset.ts
@@ -1,0 +1,27 @@
+export type AssetStatus = 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED';
+
+export interface Asset {
+  id: string;
+  assetBarcode: string;
+  assetType: string;
+  status: AssetStatus;
+  primaryIdentifier: string;
+  secondaryIdentifier?: string;
+  wing: string;
+  wingInShort?: string;
+  room?: string;
+  floor?: string;
+  floorInWords?: string;
+  roomNo?: string;
+  roomName?: string;
+  filterNeeded: boolean;
+  filtersOn: boolean;
+  filterExpiryDate?: string;
+  filterInstalledOn?: string;
+  notes?: string;
+  augmentedCare: boolean;
+  created: string;
+  createdBy?: string;
+  modified: string;
+  modifiedBy?: string;
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noImplicitAny": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/api/*": ["src/api/*"],
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Introduces isolated `mobile/` Expo React Native app without modifying the Next.js web app
- Adds Cognito authentication, asset list/detail/edit/create flows
- Integrates barcode scanning for `assetBarcode`, React Query persistence for offline caching, and a basic theme

## Mobile app highlights
- Authentication via AWS Amplify Cognito (env-configurable)
- Axios client attaches ID token when available
- Asset screens: Home (list + refresh), Details, Edit, Create
- Barcode/QR scanning using `expo-barcode-scanner`
- Offline caching via React Query + AsyncStorage; revalidate on reconnect
- Themed input and buttons aligned with web primary color

## How to run
```bash
cd mobile
npm install
# Optional env overrides
export EXPO_PUBLIC_API_BASE_URL="https://r1iqp059n5.execute-api.eu-west-2.amazonaws.com/dev"
export EXPO_PUBLIC_COGNITO_USER_POOL_ID="eu-west-2_uZhfIxAA7"
export EXPO_PUBLIC_COGNITO_USER_POOL_CLIENT_ID="24a2n8fjsq4tvrtfdgtqkp71fl"

npm start
# press i for iOS, a for Android, or scan QR with Expo Go
```

## Test plan
- Login
  - Launch app; enter valid Cognito email/password -> navigates to Home
  - Invalid creds -> remain on login
- Asset List
  - Pull-to-refresh reloads assets
  - Tap an item -> navigates to details
- Asset Details/Edit
  - Edit asset fields and save -> success message, back to details
- Create Asset
  - Tap “+ Add”; fill fields and create -> success message, list updates
  - Tap “Scan Barcode” and scan -> barcode pre-fills in the form
- Offline
  - Turn on airplane mode -> list uses cached data; turn off -> refetches

## Notes
- Web app remains untouched; this is a separate `mobile/` directory.
- No breaking changes to existing code; mobile lives on its own branch.